### PR TITLE
Copy movement hack from Pyromancer.

### DIFF
--- a/src/bas/movement.hpp
+++ b/src/bas/movement.hpp
@@ -1,0 +1,66 @@
+#pragma once
+#include <SDL.h>
+
+#include <array>
+#include <tuple>
+
+namespace base {
+/// @brief Simple mapping of movement keys to directions.
+struct MoveKey {
+  int scancode;
+  int dx;
+  int dy;
+};
+
+// clang-format off
+/// @brief A list of common movement keys.
+static constexpr std::array MOVE_KEYS {
+    MoveKey{SDL_SCANCODE_A, -1, 0},
+    MoveKey{SDL_SCANCODE_D, 1, 0},
+    MoveKey{SDL_SCANCODE_W, 0, -1},
+    MoveKey{SDL_SCANCODE_S, 0, 1},
+    MoveKey{SDL_SCANCODE_LEFT, -1, 0},
+    MoveKey{SDL_SCANCODE_RIGHT, 1, 0},
+    MoveKey{SDL_SCANCODE_UP, 0, -1},
+    MoveKey{SDL_SCANCODE_DOWN, 0, 1},
+    MoveKey{SDL_SCANCODE_KP_4, -1, 0},
+    MoveKey{SDL_SCANCODE_KP_6, 1, 0},
+    MoveKey{SDL_SCANCODE_KP_8, 0, -1},
+    MoveKey{SDL_SCANCODE_KP_2, 0, 1},
+
+    MoveKey{SDL_SCANCODE_KP_7, -1, -1},
+    MoveKey{SDL_SCANCODE_KP_1, -1, 1},
+    MoveKey{SDL_SCANCODE_KP_9, 1, -1},
+    MoveKey{SDL_SCANCODE_KP_3, 1, 1},
+
+    MoveKey{SDL_SCANCODE_HOME, -1, -1},
+    MoveKey{SDL_SCANCODE_END, -1, 1},
+    MoveKey{SDL_SCANCODE_PAGEUP, 1, -1},
+    MoveKey{SDL_SCANCODE_PAGEDOWN, 1, 1},
+
+    MoveKey{SDL_SCANCODE_H, -1, 0},
+    MoveKey{SDL_SCANCODE_J, 0, 1},
+    MoveKey{SDL_SCANCODE_K, 0, -1},
+    MoveKey{SDL_SCANCODE_L, 1, 0},
+    MoveKey{SDL_SCANCODE_Y, -1, -1},
+    MoveKey{SDL_SCANCODE_U, 1, -1},
+    MoveKey{SDL_SCANCODE_B, -1, 1},
+    MoveKey{SDL_SCANCODE_N, 1, 1},
+};
+// clang-format on
+
+/// @brief Return the current direction from the active keyboard state.
+/// @return A {dx, dy} tuple of all held keys.
+inline auto get_current_movement_dir() -> std::tuple<int, int> {
+  const auto* keyboard_state = SDL_GetKeyboardState(NULL);
+  int dx = 0;
+  int dy = 0;
+  for (const auto& move_key : MOVE_KEYS) {
+    if (keyboard_state[move_key.scancode]) {
+      dx += move_key.dx;
+      dy += move_key.dy;
+    }
+  }
+  return {dx, dy};
+}
+}  // namespace base

--- a/src/mob/mob_player.cpp
+++ b/src/mob/mob_player.cpp
@@ -28,6 +28,7 @@
 #include <assert.h>
 #include <ctype.h>
 
+#include "bas/movement.hpp"
 #include "main.hpp"
 #include "util_subcell.hpp"
 
@@ -367,7 +368,14 @@ bool Player::update(float elapsed, TCOD_key_t key, TCOD_mouse_t* mouse) {
   // update fov according to breath
   computeFovRange(elapsed);
 
-  Player::getMoveKey(key, &up, &down, &left, &right);
+  {
+    // Hack to fix movement.
+    auto [new_dx, new_dy] = base::get_current_movement_dir();
+    left = new_dx < 0;
+    right = new_dx > 0;
+    up = new_dy < 0;
+    down = new_dy > 0;
+  }
 
   // mouse coordinates
   int dungeonx = mouse->cx + gameEngine->xOffset;

--- a/src/mob/mob_player.hpp
+++ b/src/mob/mob_player.hpp
@@ -47,7 +47,7 @@ class Player : public Creature {
   void setLightColor(TCODColor col) { light.color = col; }
   float getHealing();
   float getHealth();
-  static void getMoveKey(TCOD_key_t key, bool* up, bool* down, bool* left, bool* right);
+  [[depreaced]] static void getMoveKey(TCOD_key_t key, bool* up, bool* down, bool* left, bool* right);
   inline float getAverageSpeed() { return averageSpeed; }
   void computeStealth(float elapsed);
 


### PR DESCRIPTION
This code might be refined later into something better. Right now it shows a little of how to work with SDL.

Marked `getMoveKey` with `[[deprecated]]`.  For now this is an attempt to phase it out.

Fixes #8 